### PR TITLE
feat(services): run npm install + build

### DIFF
--- a/src/commands/create/birth.ts
+++ b/src/commands/create/birth.ts
@@ -43,7 +43,7 @@ export class CreateBirthCommand extends Command {
       name: this.name,
       yes: this.yes
     })
-    await leon.install()
+    await leon.createBirth()
     return 0
   }
 }

--- a/src/services/Leon.ts
+++ b/src/services/Leon.ts
@@ -4,8 +4,6 @@ import * as fsWithCallbacks from 'fs'
 
 import axios from 'axios'
 import ora from 'ora'
-import execa from 'execa'
-import getStream from 'get-stream'
 import extractZip from 'extract-zip'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -48,7 +46,7 @@ export class Leon implements LeonOptions {
       version,
       useDocker = false,
       name = uuidv4(),
-      yes: yes = false
+      yes = false
     } = options
     this.useDevelopGitBranch = useDevelopGitBranch
     this.birthPath =
@@ -117,19 +115,7 @@ export class Leon implements LeonOptions {
     }
   }
 
-  public async buildDockerImage (): Promise<void> {
-    const loader = ora('Building the Leon Docker image').start()
-    const dockerBuildStream = execa('npm', ['run', 'docker:build']).stdout
-    if (dockerBuildStream == null) {
-      return
-    }
-    dockerBuildStream.pipe(process.stdout)
-    const value = await getStream(dockerBuildStream)
-    console.log(value)
-    loader.succeed()
-  }
-
-  public async install (): Promise<void> {
+  public async createBirth (): Promise<void> {
     if (await isExistingFile(this.birthPath)) {
       return await log.error({
         stderr: `${this.birthPath} already exists, please provide another path.`,
@@ -151,9 +137,5 @@ export class Leon implements LeonOptions {
       mode: this.useDocker ? 'docker' : 'classic',
       path: this.birthPath
     })
-    process.chdir(this.birthPath)
-    if (this.useDocker) {
-      await this.buildDockerImage()
-    }
   }
 }

--- a/src/services/__test__/LeonInstance.test.ts
+++ b/src/services/__test__/LeonInstance.test.ts
@@ -1,14 +1,19 @@
 import fsMock from 'mock-fs'
 
 import { Config, ConfigData } from '../Config'
-import { LeonInstance, LeonInstanceOptions } from '../LeonInstance'
+import { CreateOptions, LeonInstance, LeonInstanceOptions } from '../LeonInstance'
 import { log } from '../Log'
 
 const leonInstanceOptions: LeonInstanceOptions = {
   name: 'random-name',
   birthDate: 'birthDate',
-  mode: 'classic',
+  mode: 'docker',
   path: '/path'
+}
+
+const leonCreateOptions: CreateOptions = {
+  ...leonInstanceOptions,
+  shouldBuild: false
 }
 
 const leonInstance = new LeonInstance(leonInstanceOptions)
@@ -93,17 +98,18 @@ describe('services/LeonInstance - create', () => {
       [log.path]: {},
       [Config.PATH]: JSON.stringify(configData)
     })
-    await LeonInstance.create(leonInstanceOptions)
+    await LeonInstance.create(leonCreateOptions)
     expect(console.error).toHaveBeenCalled()
     expect(process.exit).toHaveBeenCalled()
   })
 
   it('should create the new instance', async () => {
     fsMock({
+      '/path': {},
       [log.path]: {},
       [Config.FOLDER_PATH]: {}
     })
-    await LeonInstance.create(leonInstanceOptions)
+    await LeonInstance.create(leonCreateOptions)
     const config = await Config.get()
     expect(config.data.instances.length).toEqual(1)
     expect(config.data.instances[0].name).toEqual(leonInstance.name)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "allowJs": false,
     "checkJs": false,
     "declaration": false,
-    "sourceMap": false,
+    "sourceMap": true,
     "outDir": "./build",
     "rootDir": "./src",
     "removeComments": false,


### PR DESCRIPTION
<!--

Please first discuss the change you wish to make via issue before making a change. It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon-cli/blob/master/CONTRIBUTING.md

-->

## What changes this PR introduce?

Add the `install` and `build` methods for the `LeonInstance` class, to do `npm install` and `npm run build` when creating a new instance.

## Is there anything you'd like reviewers to focus on?

- How can I write automated tests for that ? It will probably be tested thanks to e2e tests that we will do later, but I don't know if it is possible to write unit tests for that.