### PR TITLE
fix: use correct pacman option on archlinux

### DIFF
--- a/scripts/dependencies/install_pacman_packages.sh
+++ b/scripts/dependencies/install_pacman_packages.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pacman --sync --needed --yes base-devel openssl zlib xz git bash
+pacman --sync --needed --noconfirm base-devel openssl zlib xz git bash


### PR DESCRIPTION
The `--yes` option does not exist. One can use `--noconfirm` instead (or simply let user decide what to do).

Fix #193 