### PR TITLE
fix(scripts): argument `--yes` in `yum install` is unrecognized

### DIFF
--- a/scripts/dependencies/install_yum_packages.sh
+++ b/scripts/dependencies/install_yum_packages.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-yum install --yes gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel git bash curl
+yes | yum install gcc zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel git bash curl


### PR DESCRIPTION
`--yes` is not a valid argument but `-y`. Replacing `--yes` with `-y` or using `yes` CLI can resolve this.

Resolves: leon-ai/leon-cli/issues/195#issue-1363352738

<!--

Please first discuss the change you wish to make via issue before making a change. It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon-cli/blob/master/CONTRIBUTING.md

-->

## What changes this PR introduce?
Removed `--yes` argument from `scripts/dependencies/install_yum_packages.sh` and used `yes` command instead.

## List any relevant issue numbers
#195 

## Is there anything you'd like reviewers to focus on?
No.
