### PR TITLE
drop .gitattributes to resolve leon-ai/leon-cli#203

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf


### PR DESCRIPTION
## What changes this PR introduce?
it drops .gitattributes file with only one line, which had been obsolete with up-to-date Git client

## List any relevant issue numbers
issue in question is #203

## Is there anything you'd like reviewers to focus on?
not much, it's obvious provided we agree that single-line file is obsolete
